### PR TITLE
Change workflow to just publish Docker image to package on push

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,13 +6,13 @@ on: [push]
 
 jobs:
   build-and-publish:
+    env:
+      IMAGE_NAME: service-tracker-web
     name: Build and Publish App
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
-        with:
-          node-version: 12
       - run: npm ci
       - run: npm run build --if-present
       - uses: docker/build-push-action@v1
@@ -20,7 +20,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
           registry: docker.pkg.github.com
-          repository: cloudnativegbb/arcdemo-service-tracker-ui/service-tracker-web
+          repository: cloudnativegbb/arcdemo-service-tracker-ui/${{ env.IMAGE_NAME }}
           tags: latest
           tag_with_ref: true
           add_git_labels: true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
           registry: docker.pkg.github.com
-          repository: cloudnativegbb/arcdemo-service-tracker-ui/service-tracker-ui
+          repository: cloudnativegbb/arcdemo-service-tracker-ui/service-tracker-web
           tags: latest
           tag_with_ref: true
           add_git_labels: true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,3 +22,5 @@ jobs:
           registry: docker.pkg.github.com
           repository: cloudnativegbb/arcdemo-service-tracker-ui
           tags: latest
+          tag_with_ref: true
+          add_git_labels: true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,26 +1,31 @@
-name: Docker Build for GH and DH
+# This workflow will run tests using node and then publish a package for the UI to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Service Tracker UI Package
+
 on: [push]
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        name: cloudnativegbb/arc-k8s-demos/service-tracker-ui
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        dockerfile: Dockerfile
-        registry: docker.pkg.github.com
-        snapshot: true
-    - uses: actions/checkout@master
-    - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        name: msftgbb/service-tracker-ui
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
-        dockerfile: Dockerfile
-        registry: docker.io
-        snapshot: true
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm ci
+      - run: npm run build
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://npm.pkg.github.com/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,9 +18,9 @@ jobs:
       - uses: docker/build-push-action@v1
         with:
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ github.token }}
           registry: docker.pkg.github.com
-          repository: cloudnativegbb/arcdemo-service-tracker-ui
+          repository: cloudnativegbb/arcdemo-service-tracker-ui/service-tracker-ui
           tags: latest
           tag_with_ref: true
           add_git_labels: true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,5 +20,5 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: docker.pkg.github.com
-          repository: https://github.com/CloudNativeGBB/arcdemo-service-tracker-ui
-          tag_with_ref: true
+          repository: cloudnativegbb/arcdemo-service-tracker-ui
+          tags: latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,12 +1,12 @@
 # This workflow will run tests using node and then publish a package for the UI to GitHub Packages when a release is created
 # For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
 
-name: Service Tracker UI Package
-
+name: Package Service Tracker UI
 on: [push]
 
 jobs:
-  build:
+  build-and-publish:
+    name: Build and Publish App
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -14,18 +14,11 @@ jobs:
         with:
           node-version: 12
       - run: npm ci
-      - run: npm run build
-
-  publish-gpr:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - run: npm run build --if-present
+      - uses: docker/build-push-action@v1
         with:
-          node-version: 12
-          registry-url: https://npm.pkg.github.com/
-      - run: npm ci
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          repository: https://github.com/CloudNativeGBB/arcdemo-service-tracker-ui
+          tag_with_ref: true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,13 @@
 {
-  "name": "gbb-kubernetes-hackfest-webui-dashboard",
+  "name": "@cloudnativegbb/service-tracker-ui",
   "version": "1.0.0",
-  "private": true,
+  "publishConfig": {
+    "registry":"https://npm.pkg.github.com/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/CloudNativeGBB/arcdemo-service-tracker-ui.git"
+  },
   "scripts": {
     "local": "vue-cli-service serve",
     "dev": "vue-cli-service serve",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "local": "vue-cli-service serve",
     "dev": "vue-cli-service serve",
     "container": "vue-cli-service serve",
-    "build": "vue-cli-service serve"
+    "build": "vue-cli-service build"
   },
   "dependencies": {
     "async": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "local": "vue-cli-service serve",
     "dev": "vue-cli-service serve",
-    "container": "vue-cli-service serve"
+    "container": "vue-cli-service serve",
+    "build": "vue-cli-service serve"
   },
   "dependencies": {
     "async": "^2.6.1",


### PR DESCRIPTION
Removes Docker build and uses `npm` to build and publish to Github package.